### PR TITLE
Better support of timing BBs w/ memory accesses

### DIFF
--- a/timing_tools/timing/gettiming.py
+++ b/timing_tools/timing/gettiming.py
@@ -38,7 +38,9 @@ def remove_unrecog_words(line):
 
 def add_memory_prefix(line):
     mem = re.search('.*\[(.*)\].*', line)
-    if mem != None and 'rsp' not in line:
+    if (mem != None and
+        re.match('.*(rsp|rbp|esp|ebp)', mem.group(1)) is None and
+        not line.strip().startswith('lea')):
         index = mem.span(1)[0]
         line = line[:index] + 'UserData + ' + line[index:]
     return line


### PR DESCRIPTION
The following changes allows us to time ~50 to 60% of the blocks that we were not able to before.

- zero initialize most registers
- point stack and frame pointers to middle of `UserData`
- remove `UserData` prefix in the following cases
 - memory address involved in `lea`
 - memory address that uses `rsp` or `rbp`

Changes between the two `rdtsc` calls are:
- remove the initialization code in the `SERIALIZE` macro 
- zero initialize `r[a|b|c|d]x`